### PR TITLE
Fix: Removed useless formatting url parameters

### DIFF
--- a/src/endpoints/buckets.rs
+++ b/src/endpoints/buckets.rs
@@ -87,8 +87,7 @@ async fn delete_bucket(cxt: SearcherData, path: web::Path<String>) -> HttpRespon
 #[get("/{bucket_name}")]
 async fn get_bucket(cxt: SearcherData, path: web::Path<String>) -> JsonResponse<Bucket> {
     let client = cxt.get_ref();
-    let bucket_name = format!("/{}/_stats", path);
-    client.get_bucket(bucket_name.as_str()).await
+    client.get_bucket(path.as_str()).await
 }
 
 #[cfg(test)]

--- a/src/endpoints/clusters.rs
+++ b/src/endpoints/clusters.rs
@@ -71,8 +71,7 @@ async fn delete_cluster(cxt: SearcherData, path: web::Path<String>) -> HttpRespo
 #[get("/{cluster_name}")]
 async fn get_cluster(cxt: SearcherData, path: web::Path<String>) -> JsonResponse<Cluster> {
     let client = cxt.get_ref();
-    let cluster_name = format!("/_nodes/{}", path);
-    client.get_cluster(cluster_name.as_str()).await
+    client.get_cluster(path.as_str()).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
There are following changes on `fix/remove-useless-formatting` branch:
 - Removed formatting url parameters into endpoints module.