### PR TITLE
Merge: Fixes after demo

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,4 @@ LOGGER_SERVICE_HOST=http://localhost:4444
 OCR_SERVICE_HOST=http://localhost:8083
 
 CORS_ORIGIN=http://localhost:3000
+GLOBAL_FOLDERS=history,unrecognized

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     environment:
       - discovery.type=single-node
       - cluster.name=master
-      - ELASTIC_PASSWORD=elasticsearch
+      - ELASTIC_PASSWORD=elastic
+      - ES_JAVA_OPTS=-Xms2g -Xmx2g
     ulimits:
       memlock:
         soft: -1
@@ -21,20 +22,26 @@ services:
     volumes:
       - esdata1:/usr/share/elasticsearch/data
 
-  docsearcher:
+  doc-searcher:
     depends_on:
       - elasticsearch
     image: doc-searcher:latest
     container_name: doc-searcher
     environment:
-      - ELASTIC_HOST=http://elasticsearch:9200
-      - ELASTIC_PASSWORD=elasticsearch
-      - ELASTIC_USER=elasticsearch
-      - SEARCHER_ADDRESS=0.0.0.0
+      - SEARCHER_HOST=0.0.0.0
       - SEARCHER_PORT=2892
-      - CACHER_HOST=redis://cacher:6379
+      - ELASTIC_SERVICE_HOST=http://elasticsearch:9200
+      - ELASTIC_SERVICE_PASSWORD=elastic
+      - ELASTIC_SERVICE_USERNAME=elastic
+      - CACHER_SERVICE_HOST=redis://cacher:6379
+      - CACHER_PASSWORD=redis
       - CACHER_EXPIRE=3600
+      - LLM_SERVICE_HOST=http://localhost:8085
+      - WATCHER_SERVICE_HOST=http://localhost:2893
+      - LOGGER_SERVICE_HOST=http://localhost:4444
+      - OCR_SERVICE_HOST=http://localhost:8083
       - CORS_ORIGIN=http://localhost:3000
+      - GLOBAL_FOLDERS=history,unrecognized
     ports:
       - "2892:2892"
     networks:
@@ -42,19 +49,26 @@ services:
     volumes:
       - dsdata1:/archiver
 
-  docnotifier:
+  doc-notifier:
     depends_on:
-      - docsearcher
+      - doc-searcher
     image: doc-notifier:latest
     container_name: doc-notifier
     restart: on-failure
     environment:
-      - IS_LOAD_CHUNKS=true
-      - READ_RAW_FILE=false
-      - LLM_ADDRESS=http://localhost:8000
-      - OCR_ADDRESS=http://localhost:9091
-      - DOC_ADDRESS=http://docsearcher:2892
-      - WATCHER_DIR_PATHS=/indexer
+      - DOC_NOTIFIER_SERVICE_ADDRESS=0.0.0.0:2893
+      - DOC_NOTIFIER_WATCHED_DIRS=./indexer/watcher
+      - DOC_NOTIFIER_ENABLE_FILE_LOG=false
+      - OCR_SERVICE_ADDRESS=http://localhost:1231
+      - OCR_SERVICE_MODE=read-raw-file
+      - DOC_SEARCHER_SERVICE_ADDRESS=http://doc-searcher:2892
+      - TOKENIZER_MODE=none
+      - TOKENIZER_CHUNK_SIZE=800
+      - TOKENIZER_CHUNK_OVERLAP=100
+      - TOKENIZER_RETURN_CHUNKS=false
+      - TOKENIZER_CHUNK_BY_SELF=false
+      - TOKENIZER_TIMEOUT_SECONDS=300
+      - TOKENIZER_SERVICE_ADDRESS=http://localhost:8001
     ports:
       - "9800:9800"
     networks:
@@ -64,7 +78,7 @@ services:
 
   cacher:
     depends_on:
-      - docsearcher
+      - doc-searcher
     image: redis:latest
     restart: on-failure
     ports:

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -50,6 +50,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .service(build_watcher_scope())
     })
     .bind((service_addr, *service_port))?
+    .workers(6)
     .run()
     .await?;
 

--- a/src/crates/wrappers/src/bucket.rs
+++ b/src/crates/wrappers/src/bucket.rs
@@ -51,10 +51,12 @@ impl Folder {
     }
 }
 
-#[derive(Deserialize, IntoParams, ToSchema)]
+#[derive(Deserialize, IntoParams, Serialize, ToSchema)]
 pub struct FolderForm {
     #[schema(example = "test_folder")]
     folder_id: String,
+    #[schema(example = "true")]
+    is_preview_schema: bool,
 }
 
 impl Display for FolderForm {
@@ -66,14 +68,15 @@ impl Display for FolderForm {
 
 impl Default for FolderForm {
     fn default() -> Self {
-        FolderForm::new(DEFAULT_FOLDER_NAME)
+        FolderForm::new(DEFAULT_FOLDER_NAME, true)
     }
 }
 
 impl FolderForm {
-    pub fn new(bucket_name: &str) -> Self {
+    pub fn new(folder_id: &str, is_preview: bool) -> Self {
         FolderForm {
-            folder_id: bucket_name.to_string(),
+            folder_id: folder_id.to_string(),
+            is_preview_schema: is_preview,
         }
     }
 
@@ -81,7 +84,11 @@ impl FolderForm {
         FolderBuilder::default()
     }
 
-    pub fn get_name(&self) -> &str {
+    pub fn get_id(&self) -> &str {
         self.folder_id.as_str()
+    }
+
+    pub fn is_preview(&self) -> bool {
+        self.is_preview_schema
     }
 }

--- a/src/crates/wrappers/src/document.rs
+++ b/src/crates/wrappers/src/document.rs
@@ -156,7 +156,7 @@ pub struct Artifacts {
     #[schema(example = "tn_info")]
     pub group_json_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub group_values: Option<Vec<GroupValue>>
+    pub group_values: Option<Vec<GroupValue>>,
 }
 
 #[derive(Builder, Clone, Deserialize, Serialize, ToSchema)]
@@ -174,11 +174,10 @@ pub struct GroupValue {
 }
 
 fn deser_group_value<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-    where
-        D: Deserializer<'de>,
+where
+    D: Deserializer<'de>,
 {
-    String::deserialize(deserializer)
-        .and_then(|value| Ok(Some(value.replace("-", "   "))))
+    String::deserialize(deserializer).and_then(|value| Ok(Some(value.replace("-", "   "))))
 }
 
 #[derive(Builder, Clone, Default, Deserialize, Serialize, ToSchema)]
@@ -237,15 +236,16 @@ impl TestExample<DocumentPreview> for DocumentPreview {
                 vec![ArtifactsBuilder::default()
                     .group_name("Information of TN".to_string())
                     .group_json_name("tn_info".to_string())
-                    .group_values(vec![
-                        GroupValueBuilder::default()
+                    .group_values(
+                        vec![GroupValueBuilder::default()
                             .name("Date of TN".to_string())
                             .json_name("date_of_tn".to_string())
                             .group_type("string".to_string())
                             .value(Some("2023-10-29".to_string()))
                             .build()
-                            .unwrap()
-                    ].into())
+                            .unwrap()]
+                        .into(),
+                    )
                     .build()
                     .unwrap()]
                 .into(),
@@ -285,7 +285,7 @@ impl MoveDocumetsForm {
     pub fn get_src_folder_id(&self) -> &str {
         self.src_folder_id.as_str()
     }
-    
+
     pub fn get_document_ids(&self) -> &[String] {
         self.document_ids.as_slice()
     }

--- a/src/crates/wrappers/src/document.rs
+++ b/src/crates/wrappers/src/document.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
 
 use datetime::{deserialize_dt, serialize_dt};
 use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Deserialize, Serialize, Builder, Default, Clone, ToSchema)]
@@ -12,6 +12,14 @@ pub struct Document {
     pub folder_id: String,
     #[schema(example = "/test_folder")]
     pub folder_path: String,
+    #[schema(example = "98ac9896be35f47fb8442580cd9839b4")]
+    pub content_md5: String,
+    #[schema(example = "a9850114-5903-465a-bfc5-8d9e28110be8")]
+    pub content_uuid: String,
+    #[schema(example = "The Ocean Carrier has been signed.")]
+    pub content: String,
+    #[serde(default)]
+    pub content_vector: Vec<f64>,
     #[schema(example = "98ac9896be35f47fb8442580cd9839b4")]
     pub document_md5: String,
     #[schema(example = "12:JOGnP+EfzRR00C+guy:DIFJrukvZRRWWATP+Eo70y")]
@@ -28,14 +36,6 @@ pub struct Document {
     pub document_extension: String,
     #[schema(example = 777)]
     pub document_permissions: i32,
-    #[schema(example = "98ac9896be35f47fb8442580cd9839b4")]
-    pub content_md5: String,
-    #[schema(example = "a9850114-5903-465a-bfc5-8d9e28110be8")]
-    pub content_uuid: String,
-    #[schema(example = "The Ocean Carrier has been signed.")]
-    pub content: String,
-    #[serde(default)]
-    pub content_vector: Vec<f64>,
     #[serde(
         serialize_with = "serialize_dt",
         deserialize_with = "deserialize_dt",
@@ -169,7 +169,16 @@ pub struct GroupValue {
     #[serde(rename = "type")]
     pub group_type: String,
     #[schema(example = "2023-10-29")]
+    #[serde(deserialize_with = "deser_group_value")]
     pub value: Option<String>,
+}
+
+fn deser_group_value<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)
+        .and_then(|value| Ok(Some(value.replace("-", "   "))))
 }
 
 #[derive(Builder, Clone, Default, Deserialize, Serialize, ToSchema)]
@@ -265,6 +274,7 @@ impl From<Document> for DocumentPreview {
 pub struct MoveDocumetsForm {
     document_ids: Vec<String>,
     folder_id: String,
+    src_folder_id: String,
 }
 
 impl MoveDocumetsForm {
@@ -272,6 +282,10 @@ impl MoveDocumetsForm {
         self.folder_id.as_str()
     }
 
+    pub fn get_src_folder_id(&self) -> &str {
+        self.src_folder_id.as_str()
+    }
+    
     pub fn get_document_ids(&self) -> &[String] {
         self.document_ids.as_slice()
     }
@@ -281,6 +295,7 @@ impl TestExample<MoveDocumetsForm> for MoveDocumetsForm {
     fn test_example(_value: Option<&str>) -> MoveDocumetsForm {
         MoveDocumetsFormBuilder::default()
             .folder_id("test_folder".to_string())
+            .src_folder_id("unrecognized".to_string())
             .document_ids(vec!["98ac9896be35f47fb8442580cd9839b4".to_string()])
             .build()
             .unwrap()

--- a/src/crates/wrappers/src/schema.rs
+++ b/src/crates/wrappers/src/schema.rs
@@ -11,7 +11,7 @@ enum FieldType {
 #[derive(Serialize)]
 pub struct PreviewDocumentSchema {
     _source: EnabledFlag,
-    properties: PropertiesSchema
+    properties: PropertiesSchema,
 }
 
 impl Default for PreviewDocumentSchema {
@@ -47,8 +47,6 @@ impl Default for PreviewPropertiesSchema {
         }
     }
 }
-
-
 
 #[derive(Serialize)]
 pub struct DocumentSchema {

--- a/src/crates/wrappers/src/schema.rs
+++ b/src/crates/wrappers/src/schema.rs
@@ -1,23 +1,78 @@
 use serde_derive::Serialize;
 
-#[derive(Default, Serialize)]
-pub struct BucketSchema {
+enum FieldType {
+    Date,
+    Dense,
+    Integer,
+    String,
+    Object,
+}
+
+#[derive(Serialize)]
+pub struct PreviewDocumentSchema {
+    _source: EnabledFlag,
+    properties: PropertiesSchema
+}
+
+impl Default for PreviewDocumentSchema {
+    fn default() -> Self {
+        PreviewDocumentSchema {
+            _source: EnabledFlag::enabled(),
+            properties: PropertiesSchema::default(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PreviewPropertiesSchema {
+    id: SchemaFieldType,
+    name: SchemaFieldType,
+    location: SchemaFieldType,
+    file_size: SchemaFieldType,
+    created_at: SchemaFieldType,
+    preview_properties: SchemaFieldType,
+    quality_recognition: SchemaFieldType,
+}
+
+impl Default for PreviewPropertiesSchema {
+    fn default() -> Self {
+        PreviewPropertiesSchema {
+            id: SchemaFieldType::new(FieldType::String),
+            name: SchemaFieldType::new(FieldType::String),
+            location: SchemaFieldType::new(FieldType::String),
+            created_at: SchemaFieldType::new(FieldType::Date),
+            file_size: SchemaFieldType::new(FieldType::Integer),
+            quality_recognition: SchemaFieldType::new(FieldType::Integer),
+            preview_properties: SchemaFieldType::new_dynamic(FieldType::Object),
+        }
+    }
+}
+
+
+
+#[derive(Serialize)]
+pub struct DocumentSchema {
     _source: EnabledFlag,
     properties: PropertiesSchema,
 }
 
+impl Default for DocumentSchema {
+    fn default() -> Self {
+        DocumentSchema {
+            _source: EnabledFlag::enabled(),
+            properties: PropertiesSchema::default(),
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct PropertiesSchema {
-    _timestamp: EnabledFlag,
-
-    bucket_uuid: SchemaFieldType,
-    bucket_path: SchemaFieldType,
-
+    folder_id: SchemaFieldType,
+    folder_path: SchemaFieldType,
     content: SchemaFieldType,
     content_md5: SchemaFieldType,
     content_uuid: SchemaFieldType,
     content_vector: SchemaFieldType,
-
     document_md5: SchemaFieldType,
     document_ssdeep: SchemaFieldType,
     document_name: SchemaFieldType,
@@ -28,21 +83,19 @@ struct PropertiesSchema {
     document_permissions: SchemaFieldType,
     document_created: SchemaFieldType,
     document_modified: SchemaFieldType,
+    quality_recognition: SchemaFieldType,
+    ocr_metadata: SchemaFieldType,
 }
 
 impl Default for PropertiesSchema {
     fn default() -> Self {
         PropertiesSchema {
-            _timestamp: EnabledFlag::enabled(),
-
-            bucket_uuid: SchemaFieldType::new(FieldType::String),
-            bucket_path: SchemaFieldType::new(FieldType::String),
-
+            folder_id: SchemaFieldType::new(FieldType::String),
+            folder_path: SchemaFieldType::new(FieldType::String),
             content: SchemaFieldType::new(FieldType::String),
             content_md5: SchemaFieldType::new(FieldType::String),
             content_uuid: SchemaFieldType::new(FieldType::String),
             content_vector: SchemaFieldType::new_dense(FieldType::Dense, 1024),
-
             document_md5: SchemaFieldType::new(FieldType::String),
             document_ssdeep: SchemaFieldType::new(FieldType::String),
             document_path: SchemaFieldType::new_analyzed(FieldType::String, false),
@@ -53,15 +106,19 @@ impl Default for PropertiesSchema {
             document_permissions: SchemaFieldType::new(FieldType::Integer),
             document_created: SchemaFieldType::new(FieldType::Date),
             document_modified: SchemaFieldType::new(FieldType::Date),
+            quality_recognition: SchemaFieldType::new(FieldType::Integer),
+            ocr_metadata: SchemaFieldType::new_dynamic(FieldType::Object),
         }
     }
 }
 
-enum FieldType {
-    Date,
-    Dense,
-    Integer,
-    String,
+#[derive(Serialize)]
+struct OcrMetadataSchema {
+    job_id: SchemaFieldType,
+    text: SchemaFieldType,
+    pages_count: SchemaFieldType,
+    doc_type: SchemaFieldType,
+    artifacts: SchemaFieldType,
 }
 
 #[derive(Serialize)]
@@ -72,6 +129,8 @@ struct SchemaFieldType {
     index: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dims: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dynamic: Option<bool>,
 }
 
 impl SchemaFieldType {
@@ -81,6 +140,7 @@ impl SchemaFieldType {
             field_type,
             index: None,
             dims: None,
+            dynamic: None,
         }
     }
 
@@ -89,6 +149,7 @@ impl SchemaFieldType {
         SchemaFieldType {
             field_type,
             dims: None,
+            dynamic: None,
             index: {
                 let is_analyzed = match analyzed {
                     true => "analyzed",
@@ -105,7 +166,18 @@ impl SchemaFieldType {
         SchemaFieldType {
             field_type,
             index: None,
+            dynamic: None,
             dims: Some(dense_size),
+        }
+    }
+
+    pub fn new_dynamic(type_value: FieldType) -> Self {
+        let field_type = Self::get_type_str(type_value);
+        SchemaFieldType {
+            field_type,
+            index: None,
+            dims: None,
+            dynamic: Some(true),
         }
     }
 
@@ -115,12 +187,13 @@ impl SchemaFieldType {
             FieldType::String => "string",
             FieldType::Dense => "dense_vector",
             FieldType::Date => "date",
+            FieldType::Object => "object",
         }
         .to_string()
     }
 }
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct EnabledFlag {
     enabled: bool,
 }

--- a/src/endpoints/documents.rs
+++ b/src/endpoints/documents.rs
@@ -225,6 +225,7 @@ async fn move_documents(cxt: SearcherData, form: web::Json<MoveDocumetsForm>) ->
     client
         .move_documents(
             move_doc_form.get_folder_id(),
+            move_doc_form.get_src_folder_id(),
             move_doc_form.get_document_ids(),
         )
         .await

--- a/src/endpoints/folders.rs
+++ b/src/endpoints/folders.rs
@@ -81,9 +81,7 @@ async fn get_folder(cxt: SearcherData, path: web::Path<String>) -> JsonResponse<
     tag = "Folders",
     request_body(
         content = FolderForm,
-        example = json!({
-            "folder_id": "test_folder"
-        })
+        example = json!(FolderForm::default())
     ),
     responses(
         (
@@ -185,7 +183,7 @@ async fn create_global_folders(cxt: SearcherData) -> HttpResponse {
     let client = cxt.get_ref();
     let mut collected_errs = Vec::default();
     for global_folders_id in ["history", "unrecognized"] {
-        let folder_form = FolderForm::new(global_folders_id);
+        let folder_form = FolderForm::new(global_folders_id, true);
         let response = client.create_folder(&folder_form).await;
         if response.status() != 200 {
             collected_errs.push(global_folders_id);
@@ -278,7 +276,7 @@ mod buckets_endpoints {
 
     #[test]
     async fn test_create_folder() {
-        let bucket_form = FolderForm::new("test_folder");
+        let bucket_form = FolderForm::new("test_folder", false);
         let other_context = OtherContext::new("test".to_string());
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.status().as_u16(), 200_u16);
@@ -291,7 +289,7 @@ mod buckets_endpoints {
         let response = other_context.delete_folder("test_folder").await;
         assert_eq!(response.status().as_u16(), 400_u16);
 
-        let bucket_form = FolderForm::new("test_folder");
+        let bucket_form = FolderForm::new("test_folder", false);
 
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.status().as_u16(), 200_u16);
@@ -303,7 +301,7 @@ mod buckets_endpoints {
     #[test]
     async fn test_get_folders() {
         let other_context = OtherContext::new("test".to_string());
-        let bucket_form = FolderForm::new("test_folder");
+        let bucket_form = FolderForm::new("test_folder", false);
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.status().as_u16(), 200_u16);
 
@@ -314,7 +312,7 @@ mod buckets_endpoints {
 
     #[test]
     async fn test_get_folder_by_id() {
-        let bucket_form = FolderForm::new("test_folder");
+        let bucket_form = FolderForm::new("test_folder", false);
         let other_context = OtherContext::new("test".to_string());
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.status().as_u16(), 200_u16);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,8 @@ pub enum WebError {
     LoadFileFailed(String),
     #[error("Response error: {0}")]
     ResponseError(String),
+    #[error("Continues executing: {0}")]
+    ResponseContinues(String)
 }
 
 impl WebError {
@@ -52,6 +54,7 @@ impl WebError {
             WebError::UpdateDocument(_) => "UpdateDocumentError",
             WebError::DeleteDocument(_) => "DeleteDocumentError",
             WebError::DocumentSerializing(_) => "DocumentSerializingError",
+            WebError::ResponseContinues(_) => "ContinueExecutingResponse",
             _ => "RuntimeError",
         }
         .to_string()
@@ -89,6 +92,7 @@ impl ResponseError for WebError {
             WebError::UpdateDocument(_) => StatusCode::BAD_REQUEST,
             WebError::DeleteDocument(_) => StatusCode::BAD_REQUEST,
             WebError::DocumentSerializing(_) => StatusCode::BAD_REQUEST,
+            WebError::ResponseContinues(_) => StatusCode::PROCESSING,
             _ => StatusCode::BAD_REQUEST,
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,7 +39,7 @@ pub enum WebError {
     #[error("Response error: {0}")]
     ResponseError(String),
     #[error("Continues executing: {0}")]
-    ResponseContinues(String)
+    ResponseContinues(String),
 }
 
 impl WebError {

--- a/src/services/elastic/client.rs
+++ b/src/services/elastic/client.rs
@@ -295,7 +295,7 @@ impl SearcherService for context::ElasticContext {
                     return WebError::CreateBucket(msg).error_response();
                 }
                 SuccessfulResponse::ok_response("Ok")
-            },
+            }
             Err(err) => {
                 log::error!("Failed while parsing elastic response: {}", err);
                 WebError::CreateBucket(err.to_string()).error_response()
@@ -402,7 +402,7 @@ impl SearcherService for context::ElasticContext {
         }
     }
 
-    async fn update_document(&self, doc_form: &Document) -> HttpResponse  {
+    async fn update_document(&self, doc_form: &Document) -> HttpResponse {
         let elastic = self.get_cxt().read().await;
         let bucket_name = &doc_form.folder_id;
         let document_id = &doc_form.document_md5;
@@ -461,9 +461,16 @@ impl SearcherService for context::ElasticContext {
         }
     }
 
-    async fn move_documents(&self, folder_id: &str, src_folder_id: &str, document_ids: &[String]) -> HttpResponse {
+    async fn move_documents(
+        &self,
+        folder_id: &str,
+        src_folder_id: &str,
+        document_ids: &[String],
+    ) -> HttpResponse {
         let opts = self.get_options();
-        match watcher::move_docs_to_folder(opts.as_ref(), folder_id, src_folder_id, document_ids).await {
+        match watcher::move_docs_to_folder(opts.as_ref(), folder_id, src_folder_id, document_ids)
+            .await
+        {
             Err(err) => err.error_response(),
             Ok(response) => {
                 // TODO: Update documents after moving
@@ -549,7 +556,7 @@ impl SearcherService for context::ElasticContext {
             let _ = self.create_document_preview(folder_id.as_str(), dp).await;
         }
 
-       Ok(web::Json(analysed_docs))
+        Ok(web::Json(analysed_docs))
     }
 
     async fn get_pagination_ids(&self) -> JsonResponse<Vec<String>> {

--- a/src/services/elastic/client.rs
+++ b/src/services/elastic/client.rs
@@ -445,9 +445,9 @@ impl SearcherService for context::ElasticContext {
         }
     }
 
-    async fn move_documents(&self, folder_id: &str, document_ids: &[String]) -> HttpResponse {
+    async fn move_documents(&self, folder_id: &str, src_folder_id: &str, document_ids: &[String]) -> HttpResponse {
         let opts = self.get_options();
-        match watcher::move_docs_to_folder(opts.as_ref(), folder_id, document_ids).await {
+        match watcher::move_docs_to_folder(opts.as_ref(), folder_id, src_folder_id, document_ids).await {
             Err(err) => err.error_response(),
             Ok(response) => {
                 // TODO: Update documents after moving

--- a/src/services/elastic/context.rs
+++ b/src/services/elastic/context.rs
@@ -37,6 +37,7 @@ pub struct ContextOptions {
     ocr_service_host: String,
     watcher_service_host: String,
     llm_service_host: String,
+    global_folders: String,
 }
 
 impl Default for ContextOptions {
@@ -48,6 +49,7 @@ impl Default for ContextOptions {
             ocr_service_host: "http://localhost:8083".into(),
             watcher_service_host: "http://localhost:2893".into(),
             llm_service_host: "http://localhost:8085".into(),
+            global_folders: "common_folder".into(),
         }
     }
 }
@@ -61,6 +63,7 @@ impl From<&ServiceParameters> for ContextOptions {
             ocr_service_host: value.ocr_service_host().into(),
             watcher_service_host: value.watcher_service_host().into(),
             llm_service_host: value.llm_service_host().into(),
+            global_folders: value.global_folders().into(),
         }
     }
 }

--- a/src/services/elastic/helper.rs
+++ b/src/services/elastic/helper.rs
@@ -47,7 +47,7 @@ pub async fn send_document(
             let text = response.text().await.unwrap();
             println!("{}", text.as_str());
             SendDocumentStatus::new(true, text.as_str())
-        },
+        }
         Err(err) => {
             let err_msg = format!("Failed while loading file: {:?}", err);
             SendDocumentStatus::new(false, err_msg.as_str())
@@ -80,7 +80,7 @@ pub async fn send_document_preview(
             let text = resp.text().await.unwrap();
             println!("{}", text.as_str());
             SendDocumentStatus::new(true, text.as_str())
-        },
+        }
         Err(err) => {
             let err_msg = format!("Failed while loading file: {:?}", err);
             SendDocumentStatus::new(false, err_msg.as_str())
@@ -439,7 +439,7 @@ pub fn create_bucket_scheme(is_preview: bool) -> Value {
                 "artifacts": artifacts
             }
         });
-        return bucket_schema
+        return bucket_schema;
     }
 
     // let schema = DocumentSchema::default();

--- a/src/services/elastic/watcher.rs
+++ b/src/services/elastic/watcher.rs
@@ -9,6 +9,24 @@ use serde_json::{json, Value};
 const MOVE_FILES_URL: &str = "/watcher/files/move";
 const ANALYSE_FILES_URL: &str = "/watcher/files/analyse";
 const UNRECOGNIZED_FILES_URL: &str = "/watcher/files/unrecognized";
+const CREATE_FOLDER_URL: &str = "/watcher/folders/create";
+
+pub(crate) async fn create_watcher_folder(
+    cxt_opts: &ContextOptions,
+    folder_id: &str,
+) -> Result<SuccessfulResponse, WebError> {
+    let body = &json!({"folder_name": folder_id});
+    let target_url = format!("{}{}", cxt_opts.watcher_service_host(), CREATE_FOLDER_URL);
+    match send_watcher_request(target_url.as_str(), body).await {
+        Err(err) => Err(WebError::ResponseError(err.to_string())),
+        Ok(response) => {
+            response
+                .json::<SuccessfulResponse>()
+                .await
+                .map_err(|err| WebError::ResponseError(err.to_string()))
+        },
+    }
+}
 
 pub async fn launch_docs_analysis(
     cxt_opts: &ContextOptions,

--- a/src/services/elastic/watcher.rs
+++ b/src/services/elastic/watcher.rs
@@ -37,6 +37,12 @@ pub async fn launch_docs_analysis(
     match send_watcher_request(target_url.as_str(), body).await {
         Err(err) => Err(WebError::ResponseError(err.to_string())),
         Ok(response) => {
+            let status = &response.status();
+            println!("{}", status.as_str());
+            if status.as_u16() == 102 {
+                return Err(WebError::ResponseContinues("Processing".to_string()))
+            }
+
             response
                 .json::<Vec<DocumentPreview>>()
                 .await

--- a/src/services/elastic/watcher.rs
+++ b/src/services/elastic/watcher.rs
@@ -19,12 +19,10 @@ pub(crate) async fn create_watcher_folder(
     let target_url = format!("{}{}", cxt_opts.watcher_service_host(), CREATE_FOLDER_URL);
     match send_watcher_request(target_url.as_str(), body).await {
         Err(err) => Err(WebError::ResponseError(err.to_string())),
-        Ok(response) => {
-            response
-                .json::<SuccessfulResponse>()
-                .await
-                .map_err(|err| WebError::ResponseError(err.to_string()))
-        },
+        Ok(response) => response
+            .json::<SuccessfulResponse>()
+            .await
+            .map_err(|err| WebError::ResponseError(err.to_string())),
     }
 }
 
@@ -40,7 +38,7 @@ pub async fn launch_docs_analysis(
             let status = &response.status();
             println!("{}", status.as_str());
             if status.as_u16() == 102 {
-                return Err(WebError::ResponseContinues("Processing".to_string()))
+                return Err(WebError::ResponseContinues("Processing".to_string()));
             }
 
             response
@@ -54,7 +52,7 @@ pub async fn launch_docs_analysis(
 pub(crate) async fn move_docs_to_folder(
     cxt_opts: &ContextOptions,
     folder_id: &str,
-    src_folder_id: &str, 
+    src_folder_id: &str,
     document_ids: &[String],
 ) -> Result<SuccessfulResponse, WebError> {
     let body = &json!({

--- a/src/services/elastic/watcher.rs
+++ b/src/services/elastic/watcher.rs
@@ -54,10 +54,19 @@ pub async fn launch_docs_analysis(
 pub(crate) async fn move_docs_to_folder(
     cxt_opts: &ContextOptions,
     folder_id: &str,
+    src_folder_id: &str, 
     document_ids: &[String],
 ) -> Result<SuccessfulResponse, WebError> {
-    let body = &json!({"folder_id": folder_id, "document_ids": document_ids});
+    let body = &json!({
+        "target_directory": folder_id,
+        "source_directory": src_folder_id,
+        "document_paths": document_ids
+    });
     let target_url = format!("{}{}", cxt_opts.watcher_service_host(), MOVE_FILES_URL);
+    // for document_id in document_ids {
+    //
+    // }
+
     match send_watcher_request(target_url.as_str(), body).await {
         Err(err) => Err(WebError::ResponseError(err.to_string())),
         Ok(response) => response

--- a/src/services/init.rs
+++ b/src/services/init.rs
@@ -28,6 +28,7 @@ pub struct ServiceParameters {
     logger_service_host: String,
     ocr_service_host: String,
     cors_origin: String,
+    global_folders: String,
 }
 
 pub fn init_service_parameters() -> Result<ServiceParameters, anyhow::Error> {
@@ -52,6 +53,7 @@ pub fn init_service_parameters() -> Result<ServiceParameters, anyhow::Error> {
         .logger_service_host(extract_env_value("LOGGER_SERVICE_HOST"))
         .ocr_service_host(extract_env_value("OCR_SERVICE_HOST"))
         .cors_origin(extract_env_value("CORS_ORIGIN"))
+        .global_folders(extract_env_value("GLOBAL_FOLDERS"))
         .build();
 
     Ok(service.unwrap())

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -69,7 +69,7 @@ pub trait SearcherService {
     ) -> HttpResponse;
     async fn update_document(&self, doc_form: &Document) -> HttpResponse;
     async fn delete_document(&self, folder_id: &str, document_id: &str) -> HttpResponse;
-    async fn move_documents(&self, folder_id: &str, document_ids: &[String]) -> HttpResponse;
+    async fn move_documents(&self, folder_id: &str, src_folder_id: &str, document_ids: &[String]) -> HttpResponse;
 
     async fn load_file_to_bucket(&self, folder_id: &str, file_path: &str) -> HttpResponse;
     async fn download_file(&self, folder_id: &str, file_path: &str) -> Option<NamedFile>;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -69,7 +69,12 @@ pub trait SearcherService {
     ) -> HttpResponse;
     async fn update_document(&self, doc_form: &Document) -> HttpResponse;
     async fn delete_document(&self, folder_id: &str, document_id: &str) -> HttpResponse;
-    async fn move_documents(&self, folder_id: &str, src_folder_id: &str, document_ids: &[String]) -> HttpResponse;
+    async fn move_documents(
+        &self,
+        folder_id: &str,
+        src_folder_id: &str,
+        document_ids: &[String],
+    ) -> HttpResponse;
 
     async fn load_file_to_bucket(&self, folder_id: &str, file_path: &str) -> HttpResponse;
     async fn download_file(&self, folder_id: &str, file_path: &str) -> Option<NamedFile>;

--- a/src/services/own_engine/client.rs
+++ b/src/services/own_engine/client.rs
@@ -126,7 +126,7 @@ impl SearcherService for OtherContext {
 
     async fn create_folder(&self, bucket_form: &FolderForm) -> HttpResponse {
         let cxt = self.get_cxt().write().await;
-        let uuid = bucket_form.get_name().to_string();
+        let uuid = bucket_form.get_id().to_string();
         let built_bucket = Folder::builder()
             .health("health".to_string())
             .status("status".to_string())
@@ -144,7 +144,7 @@ impl SearcherService for OtherContext {
         match map.insert(uuid, built_bucket.unwrap()) {
             Some(bucket) => SuccessfulResponse::ok_response(bucket.uuid.as_str()),
             None => {
-                let msg = format!("Created {}", bucket_form.get_name());
+                let msg = format!("Created {}", bucket_form.get_id());
                 log::warn!("New bucket has been created: {}", msg.as_str());
                 SuccessfulResponse::ok_response(msg.as_str())
             }

--- a/src/services/own_engine/client.rs
+++ b/src/services/own_engine/client.rs
@@ -202,7 +202,12 @@ impl SearcherService for OtherContext {
         }
     }
 
-    async fn move_documents(&self, _folder_id: &str, _src_folder_id: &str, _document_ids: &[String]) -> HttpResponse {
+    async fn move_documents(
+        &self,
+        _folder_id: &str,
+        _src_folder_id: &str,
+        _document_ids: &[String],
+    ) -> HttpResponse {
         SuccessfulResponse::ok_response("Ok")
     }
 

--- a/src/services/own_engine/client.rs
+++ b/src/services/own_engine/client.rs
@@ -202,7 +202,7 @@ impl SearcherService for OtherContext {
         }
     }
 
-    async fn move_documents(&self, _folder_id: &str, _document_ids: &[String]) -> HttpResponse {
+    async fn move_documents(&self, _folder_id: &str, _src_folder_id: &str, _document_ids: &[String]) -> HttpResponse {
         SuccessfulResponse::ok_response("Ok")
     }
 


### PR DESCRIPTION
There are following changes on `merge/fixed-after-demo` branch:
 - added new env var to .env;
 - supported new OCR feature;
 - re-impled creating folders to watcher and searcher;
 - supported new form to move docs into watcher;
 - added new WebErr enum to return 102 http code;
 - updated swagger macros after al changes;
 - impled moving documents between folders into watcher;
 - impled creating watcher folders;
 - refactored schema structures -> need TODO;
 - added env var to create global static dirs like history and unrecognized;
 - updated elastic client code after all changes.