### PR TITLE
Improve: Done refactoring 2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,8 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+     - "master/**"
   pull_request_target:
     types: [ assigned, opened, synchronize ]
 

--- a/src/crates/wrappers/src/document.rs
+++ b/src/crates/wrappers/src/document.rs
@@ -264,24 +264,44 @@ pub struct HighlightEntity {
 #[derive(Builder, Clone, Default, Deserialize, Serialize, ToSchema)]
 pub struct DocumentPreview {
     #[schema(example = "98ac9896be35f47fb8442580cd9839b4")]
-    pub id: String,
+    id: String,
     #[schema(example = "test_document.txt")]
-    pub name: String,
+    name: String,
     #[serde(
         serialize_with = "serialize_dt",
         deserialize_with = "deserialize_dt",
         skip_serializing_if = "Option::is_none"
     )]
     #[schema(example = "2024-04-03T13:51:32Z")]
-    pub created_at: Option<DateTime<Utc>>,
+    created_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub quality_recognition: Option<i32>,
+    quality_recognition: Option<i32>,
     #[schema(example = 35345)]
-    pub file_size: i32,
+    file_size: i32,
+    #[schema(example = "Test Folder")]
+    location: String,
     #[schema(example = "test_folder")]
-    pub location: String,
+    folder_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preview_properties: Option<Vec<Artifacts>>,
+    preview_properties: Option<Vec<Artifacts>>,
+}
+
+impl DocumentPreview {
+    pub fn get_id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    pub fn get_name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn get_folder_id(&self) -> &str {
+        self.folder_id.as_str()
+    }
+
+    pub fn get_location(&self) -> &str {
+        self.location.as_str()
+    }
 }
 
 impl TestExample<DocumentPreview> for DocumentPreview {
@@ -349,13 +369,13 @@ impl From<Document> for DocumentPreview {
 #[derive(Builder, Clone, Default, Deserialize, Serialize, IntoParams, ToSchema)]
 pub struct MoveDocumetsForm {
     document_ids: Vec<String>,
-    folder_id: String,
+    location: String,
     src_folder_id: String,
 }
 
 impl MoveDocumetsForm {
     pub fn get_folder_id(&self) -> &str {
-        self.folder_id.as_str()
+        self.location.as_str()
     }
 
     pub fn get_src_folder_id(&self) -> &str {
@@ -370,7 +390,7 @@ impl MoveDocumetsForm {
 impl TestExample<MoveDocumetsForm> for MoveDocumetsForm {
     fn test_example(_value: Option<&str>) -> MoveDocumetsForm {
         MoveDocumetsFormBuilder::default()
-            .folder_id("test_folder".to_string())
+            .location("Test Folder".to_string())
             .src_folder_id("unrecognized".to_string())
             .document_ids(vec!["98ac9896be35f47fb8442580cd9839b4".to_string()])
             .build()

--- a/src/crates/wrappers/src/folder.rs
+++ b/src/crates/wrappers/src/folder.rs
@@ -5,7 +5,8 @@ use utoipa::{IntoParams, ToSchema};
 use crate::TestExample;
 use std::fmt::Display;
 
-pub const DEFAULT_FOLDER_NAME: &str = "common_folder";
+pub const DEFAULT_FOLDER_ID: &str = "common_folder";
+pub const HISTORY_FOLDER_ID: &str = "history";
 
 #[derive(Builder, Clone, Default, Deserialize, Serialize, ToSchema)]
 pub struct Folder {
@@ -105,6 +106,8 @@ impl TestExample<Folder> for Folder {
 pub struct FolderForm {
     #[schema(example = "test_folder")]
     folder_id: String,
+    #[schema(example = "Text Folder")]
+    folder_name: String,
     #[schema(example = "false")]
     is_preview_schema: bool,
 }
@@ -118,14 +121,15 @@ impl Display for FolderForm {
 
 impl Default for FolderForm {
     fn default() -> Self {
-        FolderForm::new(DEFAULT_FOLDER_NAME, true)
+        FolderForm::new(DEFAULT_FOLDER_ID, "Common Folder", false)
     }
 }
 
 impl FolderForm {
-    pub fn new(folder_id: &str, is_preview: bool) -> Self {
+    pub fn new(folder_id: &str, folder_name: &str, is_preview: bool) -> Self {
         FolderForm {
             folder_id: folder_id.to_string(),
+            folder_name: folder_name.to_string(),
             is_preview_schema: is_preview,
         }
     }
@@ -136,6 +140,10 @@ impl FolderForm {
 
     pub fn get_id(&self) -> &str {
         self.folder_id.as_str()
+    }
+
+    pub fn get_name(&self) -> &str {
+        self.folder_name.as_str()
     }
 
     pub fn is_preview(&self) -> bool {

--- a/src/crates/wrappers/src/s_params.rs
+++ b/src/crates/wrappers/src/s_params.rs
@@ -1,4 +1,4 @@
-use crate::folder::DEFAULT_FOLDER_NAME;
+use crate::folder::DEFAULT_FOLDER_ID;
 use crate::TestExample;
 
 use derive_builder::Builder;
@@ -74,7 +74,7 @@ impl SearchParams {
     pub fn get_folders(&self, all_buckets: bool) -> String {
         match &self.folders {
             None if all_buckets => "*".to_string(),
-            None => DEFAULT_FOLDER_NAME.to_string(),
+            None => DEFAULT_FOLDER_ID.to_string(),
             Some(data) => data.clone(),
         }
     }
@@ -84,7 +84,7 @@ impl Default for SearchParams {
     fn default() -> Self {
         SearchParams::builder()
             .query("*".to_string())
-            .folders(Some(DEFAULT_FOLDER_NAME.to_string()))
+            .folders(Some(DEFAULT_FOLDER_ID.to_string()))
             .document_type(String::default())
             .document_extension(String::default())
             .created_date_to(String::default())

--- a/src/crates/wrappers/src/schema.rs
+++ b/src/crates/wrappers/src/schema.rs
@@ -50,7 +50,7 @@ impl Default for FieldType {
 impl serde::Serialize for FieldType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         let field_type_str = match self {
             FieldType::Date => "date",
@@ -161,7 +161,7 @@ impl Default for DocumentSchema {
                 document_created: AsDateField::default(),
                 document_modified: AsDateField::default(),
                 ocr_metadata: OcrMetadataSchema::default(),
-            }
+            },
         }
     }
 }
@@ -225,7 +225,7 @@ impl Default for DocumentPreviewSchema {
                 quality_recognition: SchemaFieldType::new(FieldType::Integer),
                 created_at: AsDateField::default(),
                 artifacts: ArtifactsSchema::default(),
-            }
+            },
         }
     }
 }
@@ -252,7 +252,7 @@ impl Default for ArtifactsSchema {
                 group_name: SchemaFieldType::new(FieldType::String),
                 group_json_name: SchemaFieldType::new(FieldType::String),
                 group_values: GroupValues::default(),
-            }
+            },
         }
     }
 }
@@ -284,7 +284,7 @@ impl Default for GroupValues {
     fn default() -> Self {
         let group_values_fields = GroupValueFields {
             field_type: FieldType::Text,
-            fields: AsDateField::default()
+            fields: AsDateField::default(),
         };
 
         GroupValues {
@@ -294,7 +294,7 @@ impl Default for GroupValues {
                 json_name: SchemaFieldType::new(FieldType::String),
                 group_type: SchemaFieldType::new(FieldType::Keyword),
                 value: group_values_fields,
-            }
+            },
         }
     }
 }

--- a/src/crates/wrappers/test/test.rs
+++ b/src/crates/wrappers/test/test.rs
@@ -13,6 +13,9 @@ mod schema_tests {
     #[test]
     fn test_document_preview_schema() {
         let doc_preview_schema = DocumentPreviewSchema::default();
-        println!("{}", serde_json::to_string_pretty(&doc_preview_schema).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&doc_preview_schema).unwrap()
+        );
     }
 }

--- a/src/endpoints/folders.rs
+++ b/src/endpoints/folders.rs
@@ -159,56 +159,6 @@ async fn delete_folder(cxt: SearcherData, path: web::Path<String>) -> HttpRespon
 
 #[utoipa::path(
     post,
-    path = "/folders/global",
-    tag = "Folders",
-    responses(
-        (
-            status = 200,
-            description = "Successful",
-            body = SuccessfulResponse,
-            example = json!(SuccessfulResponse {
-                code: 200,
-                message: "Done".to_string(),
-            }),
-        ),
-        (
-            status = 400,
-            description = "Failed while creating global folders",
-            body = ErrorResponse,
-            example = json!(ErrorResponse {
-                code: 400,
-                error: "Bad Request".to_string(),
-                message: "Failed while creating global folders".to_string(),
-            }),
-        ),
-    )
-)]
-#[post("/global")]
-async fn create_global_folders(cxt: SearcherData) -> HttpResponse {
-    let client = cxt.get_ref();
-    let mut collected_errs = Vec::default();
-    for global_folders_id in ["history", "unrecognized"] {
-        let folder_form = FolderForm::new(global_folders_id, true);
-        let response = client.create_folder(&folder_form).await;
-        if response.is_err() {
-            let err = response.err().unwrap();
-            log::error!("{:?}", err);
-            collected_errs.push(global_folders_id);
-        }
-    }
-
-    if !collected_errs.is_empty() {
-        let folders_str = collected_errs.join(", ");
-        let msg = format!("Failed while creating global buckets: {}", folders_str);
-        log::error!("{}", msg);
-        return WebError::CreateFolder(msg).error_response();
-    }
-
-    SuccessfulResponse::ok_response("Done")
-}
-
-#[utoipa::path(
-    post,
     path = "/folders/{folder_id}/documents",
     tag = "Folders",
     params(

--- a/src/endpoints/folders.rs
+++ b/src/endpoints/folders.rs
@@ -1,5 +1,5 @@
 use crate::endpoints::SearcherData;
-use crate::errors::{ErrorResponse, SuccessfulResponse, WebError};
+use crate::errors::{ErrorResponse, SuccessfulResponse};
 use crate::errors::{JsonResponse, PaginateJsonResponse};
 
 use actix_web::{delete, get, post, web, HttpResponse, ResponseError};

--- a/src/endpoints/folders.rs
+++ b/src/endpoints/folders.rs
@@ -282,9 +282,11 @@ mod buckets_endpoints {
 
     use actix_web::test;
 
+    const DEFAULT_FOLDER_ID: &str = "test_folder";
+
     #[test]
     async fn test_create_folder() {
-        let bucket_form = FolderForm::new("test_folder", false);
+        let bucket_form = FolderForm::default();
         let other_context = OtherContext::new("test".to_string());
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.unwrap().code, 200_u16);
@@ -294,22 +296,22 @@ mod buckets_endpoints {
     async fn test_delete_folder() {
         let other_context = OtherContext::new("test".to_string());
 
-        let response = other_context.delete_folder("test_folder").await;
+        let response = other_context.delete_folder(DEFAULT_FOLDER_ID).await;
         assert_eq!(response.unwrap().code, 400_u16);
 
-        let bucket_form = FolderForm::new("test_folder", false);
+        let bucket_form = FolderForm::default();
 
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.unwrap().code, 200_u16);
 
-        let response = other_context.delete_folder("test_folder").await;
+        let response = other_context.delete_folder(DEFAULT_FOLDER_ID).await;
         assert_eq!(response.unwrap().code, 200_u16);
     }
 
     #[test]
     async fn test_get_folders() {
         let other_context = OtherContext::new("test".to_string());
-        let bucket_form = FolderForm::new("test_folder", false);
+        let bucket_form = FolderForm::default();
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.unwrap().code, 200_u16);
 
@@ -320,13 +322,13 @@ mod buckets_endpoints {
 
     #[test]
     async fn test_get_folder_by_id() {
-        let bucket_form = FolderForm::new("test_folder", false);
+        let bucket_form = FolderForm::default();
         let other_context = OtherContext::new("test".to_string());
         let response = other_context.create_folder(&bucket_form).await;
         assert_eq!(response.unwrap().code, 200_u16);
 
-        let get_bucket_result = other_context.get_folder("test_folder").await;
-        let bucket_uuid = get_bucket_result.unwrap().0;
-        assert_eq!(bucket_uuid.get_uuid(), "test_folder");
+        let get_folder_result = other_context.get_folder(DEFAULT_FOLDER_ID).await;
+        let bucket_uuid = get_folder_result.unwrap().0;
+        assert_eq!(bucket_uuid.get_uuid(), DEFAULT_FOLDER_ID);
     }
 }

--- a/src/services/elastic/client.rs
+++ b/src/services/elastic/client.rs
@@ -8,7 +8,7 @@ use crate::services::searcher::GroupedDocs;
 
 use wrappers::cluster::Cluster;
 use wrappers::document::{Document, DocumentPreview, MoveDocumetsForm};
-use wrappers::folder::{Folder, FolderForm};
+use wrappers::folder::{Folder, FolderForm, HISTORY_FOLDER_ID};
 use wrappers::s_params::SearchParams;
 use wrappers::scroll::{AllScrollsForm, NextScrollForm, PaginatedResult};
 
@@ -367,9 +367,11 @@ impl SearcherService for context::ElasticContext {
         let cxt_opts = self.get_options().as_ref();
         let analysed_docs = watcher::launch_analysis(cxt_opts, document_ids).await?;
         for doc_preview in analysed_docs.iter() {
-            let folder_id = doc_preview.location.as_str().to_lowercase();
-            let _ = self.create_document_preview("история", doc_preview).await;
-            let _ = self.create_document_preview(folder_id.as_str(), doc_preview).await;
+            let folder_id = doc_preview.get_folder_id();
+            let _ = self
+                .create_document_preview(HISTORY_FOLDER_ID, doc_preview)
+                .await;
+            let _ = self.create_document_preview(folder_id, doc_preview).await;
         }
 
         Ok(web::Json(analysed_docs))

--- a/src/services/elastic/helper.rs
+++ b/src/services/elastic/helper.rs
@@ -9,8 +9,8 @@ use elquery::similar_query::SimilarQuery;
 use wrappers::document::{Document, DocumentPreview, HighlightEntity};
 use wrappers::folder::Folder;
 use wrappers::s_params::SearchParams;
-use wrappers::scroll::PaginatedResult;
 use wrappers::schema::{DocumentPreviewSchema, DocumentSchema};
+use wrappers::scroll::PaginatedResult;
 
 use actix_web::web;
 use elasticsearch::http::headers::HeaderMap;

--- a/src/services/elastic/helper.rs
+++ b/src/services/elastic/helper.rs
@@ -66,7 +66,7 @@ pub(crate) async fn store_doc_preview(
     doc_form: &DocumentPreview,
     folder_id: &str,
 ) -> Result<SuccessfulResponse, WebError> {
-    let document_id = doc_form.id.as_str();
+    let document_id = doc_form.get_id();
 
     let to_value_result = serde_json::to_value(doc_form);
     let document_json = to_value_result.unwrap();
@@ -85,7 +85,9 @@ pub(crate) async fn store_doc_preview(
     parse_elastic_response(response).await
 }
 
-pub(crate) async fn parse_elastic_response(response: Response) -> Result<SuccessfulResponse, WebError> {
+pub(crate) async fn parse_elastic_response(
+    response: Response,
+) -> Result<SuccessfulResponse, WebError> {
     if !response.status_code().is_success() {
         return Err(extract_exception(response).await);
     }
@@ -119,13 +121,10 @@ pub(crate) async fn check_duplication(
         .await
         .map_err(WebError::from)?;
 
-    let result = response
-        .json::<Value>()
-        .await
-        .map_or(false, |value| {
-            let count = value["count"].as_i64().unwrap_or(0);
-            count > 0
-        });
+    let result = response.json::<Value>().await.map_or(false, |value| {
+        let count = value["count"].as_i64().unwrap_or(0);
+        count > 0
+    });
 
     Ok(result)
 }

--- a/src/services/init.rs
+++ b/src/services/init.rs
@@ -114,7 +114,6 @@ pub fn build_folder_scope() -> Scope {
     web::scope("/folders")
         .service(folders::all_folders)
         .service(folders::create_folder)
-        .service(folders::create_global_folders)
         .service(folders::delete_folder)
         .service(folders::get_folder)
         .service(folders::get_folder_documents)

--- a/src/swagger/mod.rs
+++ b/src/swagger/mod.rs
@@ -31,7 +31,6 @@ use utoipa_swagger_ui::SwaggerUi;
         delete_cluster,
         all_folders,
         create_folder,
-        create_global_folders,
         get_folder,
         delete_folder,
         get_folder_documents,


### PR DESCRIPTION
There are following changes on `improve/refactoring-2` branch:
 - removed creating global folders endpoint;
 - encapsulating for `s_params` and `schemas`;
 - encapsulating for folders `wrappers`;
 - encapsulating for `Document` and `DocumentPreview`.
