### PR TITLE
Feature: Added including extra fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ strip = "debuginfo"
 [features]
 enable-unique-doc-id = ["dep:md5"]
 enable-cache-redis = ["dep:redis"]
+# temporary feature
+enable-multi-user = []
 default = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doc-search"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 
 [badges]

--- a/src/application/dto/document.rs
+++ b/src/application/dto/document.rs
@@ -17,6 +17,7 @@ pub struct Document {
     #[schema(example = 1024)]
     #[getset(get_copy = "pub")]
     file_size: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "There is some content data")]
     #[getset(get = "pub")]
     content: Option<String>,
@@ -26,6 +27,15 @@ pub struct Document {
     #[schema(example = 1750957115)]
     #[getset(get = "pub")]
     modified_at: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chunked_text: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    embeddings: Option<Vec<Embeddings>>,
+}
+
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
+struct Embeddings {
+    knn: Vec<f64>,
 }
 
 impl Document {

--- a/src/application/dto/founded.rs
+++ b/src/application/dto/founded.rs
@@ -10,7 +10,9 @@ pub struct FoundedDocument {
     id: String,
     folder_id: String,
     document: Document,
+    #[serde(skip_serializing_if = "Option::is_none")]
     score: Option<f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     highlight: Vec<String>,
 }
 

--- a/src/application/dto/params.rs
+++ b/src/application/dto/params.rs
@@ -11,10 +11,6 @@ const KNN_DIMENSION: u32 = 384;
 const TOKEN_LIMIT: u32 = 50;
 const OVERLAP_RATE: f32 = 0.2;
 
-pub trait QueryBuilder {
-    fn build_query(&self, extra_field: Option<&String>) -> serde_json::Value;
-}
-
 #[derive(Clone, Builder, Getters, Serialize, Deserialize, IntoParams, ToSchema)]
 #[getset(get = "pub")]
 pub struct CreateIndexParams {
@@ -88,6 +84,9 @@ pub struct ResultParams {
     #[schema(example = 0)]
     #[getset(get_copy = "pub")]
     offset: i64,
+    #[schema(example = false)]
+    #[getset(get_copy = "pub")]
+    include_extra_fields: Option<bool>,
 }
 
 #[derive(Getters, Serialize, Deserialize, IntoParams, ToSchema)]

--- a/src/infrastructure/osearch/mod.rs
+++ b/src/infrastructure/osearch/mod.rs
@@ -103,11 +103,23 @@ impl IndexManager for OpenSearchStorage {
     }
 
     async fn get_all_indexes(&self) -> StorageResult<Vec<Index>> {
+        #[cfg(feature = "enable-multi-user")]
         let offset = format!("{}*", self.config.username());
+        #[cfg(feature = "enable-multi-user")]
         let response = self
             .client
             .cat()
             .indices(CatIndicesParts::Index(&[&offset]))
+            .format("json")
+            .send()
+            .await?;
+
+        // TODO: Remove this code after full implementation multi-user supporting
+        #[cfg(not(feature = "enable-multi-user"))]
+        let response = self
+            .client
+            .cat()
+            .indices(CatIndicesParts::None)
             .format("json")
             .send()
             .await?;

--- a/src/infrastructure/osearch/mod.rs
+++ b/src/infrastructure/osearch/mod.rs
@@ -17,7 +17,10 @@ use opensearch::OpenSearch;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-use crate::application::dto::params::{CreateIndexParams, FullTextSearchParams, HybridSearchParams, KnnIndexParams, PaginateParams, RetrieveDocumentParams, SemanticSearchParams};
+use crate::application::dto::params::{
+    CreateIndexParams, FullTextSearchParams, HybridSearchParams, KnnIndexParams, PaginateParams,
+    RetrieveDocumentParams, SemanticSearchParams,
+};
 use crate::application::dto::{Document, FoundedDocument, Index};
 use crate::application::services::storage::{
     DocumentManager, DocumentSearcher, IndexManager, PaginateManager,

--- a/src/infrastructure/osearch/mod.rs
+++ b/src/infrastructure/osearch/mod.rs
@@ -17,10 +17,7 @@ use opensearch::OpenSearch;
 use serde_json::{json, Value};
 use std::sync::Arc;
 
-use crate::application::dto::params::{
-    CreateIndexParams, FullTextSearchParams, HybridSearchParams, KnnIndexParams, PaginateParams,
-    QueryBuilder, RetrieveDocumentParams, SemanticSearchParams,
-};
+use crate::application::dto::params::{CreateIndexParams, FullTextSearchParams, HybridSearchParams, KnnIndexParams, PaginateParams, RetrieveDocumentParams, SemanticSearchParams};
 use crate::application::dto::{Document, FoundedDocument, Index};
 use crate::application::services::storage::{
     DocumentManager, DocumentSearcher, IndexManager, PaginateManager,
@@ -28,6 +25,7 @@ use crate::application::services::storage::{
 use crate::application::services::storage::{PaginateResult, StorageError, StorageResult};
 use crate::infrastructure::osearch::config::OSearchConfig;
 use crate::infrastructure::osearch::dto::SourceDocument;
+use crate::infrastructure::osearch::query::{QueryBuilder, QueryBuilderParams};
 use crate::ServiceConnect;
 
 const SCROLL_LIFETIME: &str = "5m";
@@ -230,7 +228,8 @@ impl DocumentSearcher for OpenSearchStorage {
         ids: &str,
         params: &RetrieveDocumentParams,
     ) -> PaginateResult<FoundedDocument> {
-        let query = params.build_query(None);
+        let query_params = QueryBuilderParams::from(params);
+        let query = params.build_query(query_params);
         let indexes = ids.split(',').collect::<Vec<&str>>();
         let search_parts = Self::build_search_parts(&indexes);
         let response = self
@@ -254,7 +253,8 @@ impl DocumentSearcher for OpenSearchStorage {
     }
 
     async fn fulltext(&self, params: &FullTextSearchParams) -> PaginateResult<FoundedDocument> {
-        let query = params.build_query(None);
+        let query_params = QueryBuilderParams::from(params);
+        let query = params.build_query(query_params);
         let indexes = params.indexes().split(',').collect::<Vec<&str>>();
         let search_parts = Self::build_search_parts(&indexes);
         let request = self
@@ -284,7 +284,10 @@ impl DocumentSearcher for OpenSearchStorage {
             .model_id()
             .as_ref()
             .unwrap_or(self.config.semantic().model_id());
-        let query = params.build_query(Some(model_id));
+
+        let mut query_params = QueryBuilderParams::from(params);
+        query_params.set_model_id_if_none(model_id);
+        let query = params.build_query(query_params);
         let indexes = params.indexes().split(',').collect::<Vec<&str>>();
         let search_parts = Self::build_search_parts(&indexes);
         let request = self.client.search(search_parts).pretty(true).body(query);
@@ -309,7 +312,10 @@ impl DocumentSearcher for OpenSearchStorage {
             .model_id()
             .as_ref()
             .unwrap_or(self.config.semantic().model_id());
-        let query = params.build_query(Some(model_id));
+
+        let mut query_params = QueryBuilderParams::from(params);
+        query_params.set_model_id_if_none(model_id);
+        let query = params.build_query(query_params);
         let indexes = params.indexes().split(',').collect::<Vec<&str>>();
         let search_parts = Self::build_search_parts(&indexes);
         let request = self.client.search(search_parts).pretty(true).body(query);

--- a/src/infrastructure/osearch/query.rs
+++ b/src/infrastructure/osearch/query.rs
@@ -2,9 +2,12 @@ use derive_builder::Builder;
 use serde_json::{json, Value};
 
 use super::schema::HYBRID_SEARCH_PIPELINE_NAME;
-use crate::application::dto::params::{FilterParams, FullTextSearchParams, HybridSearchParams, RetrieveDocumentParams, SemanticSearchParams};
+use crate::application::dto::params::{
+    FilterParams, FullTextSearchParams, HybridSearchParams, RetrieveDocumentParams,
+    SemanticSearchParams,
+};
 
-#[derive(Builder, )]
+#[derive(Builder)]
 pub struct QueryBuilderParams {
     pub model_id: Option<String>,
     pub include_extra_fields: Option<bool>,
@@ -119,11 +122,9 @@ impl QueryBuilder for SemanticSearchParams {
 
         let exclude = params
             .include_extra_fields
-            .map(|it| {
-                match it {
-                    false => Some(["content", "chunked_text", "embeddings"].as_slice()),
-                    true => Some(["content"].as_slice())
-                }
+            .map(|it| match it {
+                false => Some(["content", "chunked_text", "embeddings"].as_slice()),
+                true => Some(["content"].as_slice()),
             })
             .unwrap_or_default();
 
@@ -160,11 +161,9 @@ impl QueryBuilder for HybridSearchParams {
 
         let exclude = params
             .include_extra_fields
-            .map(|it| {
-                match it {
-                    false => Some(["content", "chunked_text", "embeddings"].as_slice()),
-                    true => Some(["content"].as_slice())
-                }
+            .map(|it| match it {
+                false => Some(["content", "chunked_text", "embeddings"].as_slice()),
+                true => Some(["content"].as_slice()),
             })
             .unwrap_or_default();
 
@@ -204,11 +203,9 @@ impl QueryBuilder for HybridSearchParams {
 fn build_exclude_field(params: &QueryBuilderParams) -> Option<&[&str]> {
     params
         .include_extra_fields
-        .map(|it| {
-            match it {
-                false => Some(["chunked_text", "embeddings", "content"].as_slice()),
-                true => Some(["chunked_text", "embeddings"].as_slice())
-            }
+        .map(|it| match it {
+            false => Some(["chunked_text", "embeddings", "content"].as_slice()),
+            true => Some(["chunked_text", "embeddings"].as_slice()),
         })
         .unwrap_or_default()
 }

--- a/src/infrastructure/osearch/query.rs
+++ b/src/infrastructure/osearch/query.rs
@@ -1,25 +1,79 @@
+use derive_builder::Builder;
 use serde_json::{json, Value};
 
 use super::schema::HYBRID_SEARCH_PIPELINE_NAME;
-use crate::application::dto::params::{
-    FilterParams, FullTextSearchParams, HybridSearchParams, QueryBuilder, RetrieveDocumentParams,
-    SemanticSearchParams,
-};
+use crate::application::dto::params::{FilterParams, FullTextSearchParams, HybridSearchParams, RetrieveDocumentParams, SemanticSearchParams};
+
+#[derive(Builder, )]
+pub struct QueryBuilderParams {
+    pub model_id: Option<String>,
+    pub include_extra_fields: Option<bool>,
+}
+
+impl QueryBuilderParams {
+    pub fn set_model_id_if_none(&mut self, model_id: &str) {
+        if let None = self.model_id {
+            self.model_id = Some(model_id.to_string());
+        }
+    }
+}
+
+pub trait QueryBuilder {
+    fn build_query(&self, params: QueryBuilderParams) -> Value;
+}
+
+impl From<&RetrieveDocumentParams> for QueryBuilderParams {
+    fn from(params: &RetrieveDocumentParams) -> Self {
+        QueryBuilderParamsBuilder::default()
+            .model_id(None)
+            .include_extra_fields(params.result().include_extra_fields())
+            .build()
+            .unwrap()
+    }
+}
+
+impl From<&FullTextSearchParams> for QueryBuilderParams {
+    fn from(params: &FullTextSearchParams) -> Self {
+        QueryBuilderParamsBuilder::default()
+            .model_id(None)
+            .include_extra_fields(params.result().include_extra_fields())
+            .build()
+            .unwrap()
+    }
+}
+
+impl From<&HybridSearchParams> for QueryBuilderParams {
+    fn from(params: &HybridSearchParams) -> Self {
+        QueryBuilderParamsBuilder::default()
+            .model_id(params.model_id().clone())
+            .include_extra_fields(params.result().include_extra_fields())
+            .build()
+            .unwrap()
+    }
+}
+
+impl From<&SemanticSearchParams> for QueryBuilderParams {
+    fn from(params: &SemanticSearchParams) -> Self {
+        QueryBuilderParamsBuilder::default()
+            .model_id(params.model_id().clone())
+            .include_extra_fields(params.result().include_extra_fields())
+            .build()
+            .unwrap()
+    }
+}
 
 impl QueryBuilder for RetrieveDocumentParams {
-    fn build_query(&self, _: Option<&String>) -> Value {
+    fn build_query(&self, params: QueryBuilderParams) -> Value {
         let must = match self.path() {
             None => json!([{"match_all": {}}]),
             Some(path) => json!([{"match": {"file_path": path}}]),
         };
 
+        let exclude = build_exclude_field(&params);
+
         json!({
             "_source": {
-                "exclude": [
-                    "chunked_text",
-                    "embeddings",
-                    "content",
-               ]
+                "exclude": exclude,
             },
             "query": {
                 "bool": {
@@ -34,19 +88,17 @@ impl QueryBuilder for RetrieveDocumentParams {
 }
 
 impl QueryBuilder for FullTextSearchParams {
-    fn build_query(&self, _: Option<&String>) -> Value {
+    fn build_query(&self, params: QueryBuilderParams) -> Value {
         let must = match self.query() {
             None => json!([{"match_all": {}}]),
             Some(value) => json!({"match": {"content": value} }),
         };
 
+        let exclude = build_exclude_field(&params);
+
         json!({
             "_source": {
-                "exclude": [
-                    "chunked_text",
-                    "embeddings",
-                    "content",
-               ]
+                "exclude": exclude,
             },
             "query": {
                 "bool": {
@@ -61,15 +113,23 @@ impl QueryBuilder for FullTextSearchParams {
 }
 
 impl QueryBuilder for SemanticSearchParams {
-    fn build_query(&self, model_id: Option<&String>) -> Value {
+    fn build_query(&self, params: QueryBuilderParams) -> Value {
         let size = self.result().size();
-        let query = build_semantic_query(self, model_id);
+        let query = build_semantic_query(self, params.model_id.as_ref());
+
+        let exclude = params
+            .include_extra_fields
+            .map(|it| {
+                match it {
+                    false => Some(["content", "chunked_text", "embeddings"].as_slice()),
+                    true => Some(["content"].as_slice())
+                }
+            })
+            .unwrap_or_default();
 
         json!({
             "_source": {
-                "exclude": [
-                    "embeddings",
-                ]
+                "exclude": exclude,
             },
             "size": size,
             "query": {
@@ -92,18 +152,25 @@ impl QueryBuilder for SemanticSearchParams {
 }
 
 impl QueryBuilder for HybridSearchParams {
-    fn build_query(&self, model_id: Option<&String>) -> Value {
+    fn build_query(&self, params: QueryBuilderParams) -> Value {
         let query = self.query();
         let size = self.result().size();
         let knn_amount = self.knn_amount();
+        let model_id = params.model_id.as_ref();
+
+        let exclude = params
+            .include_extra_fields
+            .map(|it| {
+                match it {
+                    false => Some(["content", "chunked_text", "embeddings"].as_slice()),
+                    true => Some(["content"].as_slice())
+                }
+            })
+            .unwrap_or_default();
 
         json!({
             "_source": {
-                "exclude": [
-                    "chunked_text",
-                    "embeddings",
-                    "content",
-               ]
+                "exclude": exclude
             },
             "size": size,
             "query": {
@@ -132,6 +199,18 @@ impl QueryBuilder for HybridSearchParams {
             "search_pipeline": HYBRID_SEARCH_PIPELINE_NAME,
         })
     }
+}
+
+fn build_exclude_field(params: &QueryBuilderParams) -> Option<&[&str]> {
+    params
+        .include_extra_fields
+        .map(|it| {
+            match it {
+                false => Some(["chunked_text", "embeddings", "content"].as_slice()),
+                true => Some(["chunked_text", "embeddings"].as_slice())
+            }
+        })
+        .unwrap_or_default()
 }
 
 fn build_semantic_query(params: &SemanticSearchParams, model_id: Option<&String>) -> Value {

--- a/src/infrastructure/osearch/query.rs
+++ b/src/infrastructure/osearch/query.rs
@@ -15,7 +15,7 @@ pub struct QueryBuilderParams {
 
 impl QueryBuilderParams {
     pub fn set_model_id_if_none(&mut self, model_id: &str) {
-        if let None = self.model_id {
+        if self.model_id.is_none() {
             self.model_id = Some(model_id.to_string());
         }
     }


### PR DESCRIPTION
There are following changes on `feat/added-including-extra-fields` branch:
 - moved `QueryBuilder` trait into `osearch` infrastructure;
 - impled including extra fields;
 - removed nulls into serialized document data;
 - impled feature to switch pre-multi-user supporting.
