### PR TITLE
Fix: Enable user osearch prefix misprint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doc-search"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2021"
 
 [badges]

--- a/src/infrastructure/osearch/mod.rs
+++ b/src/infrastructure/osearch/mod.rs
@@ -116,7 +116,7 @@ impl IndexManager for OpenSearchStorage {
     #[tracing::instrument(skip(self), level = "info")]
     async fn get_all_indexes(&self) -> StorageResult<Vec<Index>> {
         #[cfg(feature = "enable-multi-user")]
-        let offset = format!("{}_*", self.config.username());
+        let offset = format!("{}-*", self.config.username());
         #[cfg(feature = "enable-multi-user")]
         let response = self
             .client


### PR DESCRIPTION
There is misprint fix into opensearch module with multi-user feature